### PR TITLE
Put the Filters page content into a paper

### DIFF
--- a/js-packages/admin-ui/pages/tenants/[tenantId]/filters.tsx
+++ b/js-packages/admin-ui/pages/tenants/[tenantId]/filters.tsx
@@ -16,7 +16,9 @@
  */
 
 import React from "react";
+import { createUseStyles } from "react-jss";
 import { useRouter } from "next/router";
+import { ThemeType } from "../../../components/theme";
 import { Layout } from "../../../components/Layout";
 import { firstOrString } from "../../../components/utils";
 import { useQuery, useQueryClient, useMutation } from "react-query";
@@ -27,8 +29,23 @@ import {
   DatasourceSuggestionCategoryField,
 } from "@openk9/rest-api";
 import { ClayInput } from "@clayui/form";
+import { ClayTooltipProvider } from "@clayui/tooltip";
+
+const useStyles = createUseStyles((theme: ThemeType) => ({
+  root: {
+    margin: [theme.spacingUnit * 2, "auto"],
+    backgroundColor: "white",
+    boxShadow: theme.baseBoxShadow,
+    width: "100%",
+    maxWidth: 1000,
+    borderRadius: theme.borderRadius,
+    overflow: "auto",
+    padding: theme.spacingUnit * 2,
+  },
+}));
 
 export default function Filter() {
+  const classes = useStyles();
   const { query } = useRouter();
   const tenantId = query.tenantId && firstOrString(query.tenantId);
 
@@ -47,29 +64,37 @@ export default function Filter() {
         { label: tenantId },
         { label: "Filters", path: `/tenants/${tenantId}/filters` },
       ]}
-    >
-      <div style={{ display: "flex", justifyContent: "end", padding: "8px" }}>
-        <ClayButtonWithIcon
-          symbol="plus"
-          onClick={() => suggestionCategories.add()}
-        />
-      </div>
-      {suggestionCategories.list
-        ?.sort((a, b) => a.priority - b.priority)
-        .map((suggestionCategory) => {
-          return (
-            <SuggestionCategoryRow
-              key={suggestionCategory.suggestionCategoryId}
-              suggestionCategory={suggestionCategory}
-              onRemove={suggestionCategories.remove}
-              onUpdate={suggestionCategories.update}
-              onAddField={suggestionCategoryFields.add}
-              onRemoveField={suggestionCategoryFields.remove}
-              onUpdateField={suggestionCategoryFields.update}
-              suggestionCategoryFields={suggestionCategoryFields.list}
+      breadcrumbsControls={
+        <div className="navbar-nav" style={{ marginRight: 16 }}>
+          <ClayTooltipProvider>
+            <ClayButtonWithIcon
+              data-tooltip-align="bottom"
+              title="Add Filter"
+              symbol="plus"
+              onClick={() => suggestionCategories.add()}
             />
-          );
-        })}
+          </ClayTooltipProvider>
+        </div>
+      }
+    >
+      <div className={classes.root}>
+        {suggestionCategories.list
+          ?.sort((a, b) => a.priority - b.priority)
+          .map((suggestionCategory) => {
+            return (
+              <SuggestionCategoryRow
+                key={suggestionCategory.suggestionCategoryId}
+                suggestionCategory={suggestionCategory}
+                onRemove={suggestionCategories.remove}
+                onUpdate={suggestionCategories.update}
+                onAddField={suggestionCategoryFields.add}
+                onRemoveField={suggestionCategoryFields.remove}
+                onUpdateField={suggestionCategoryFields.update}
+                suggestionCategoryFields={suggestionCategoryFields.list}
+              />
+            );
+          })}
+      </div>
     </Layout>
   );
 }


### PR DESCRIPTION
The current standard for admin pages is to have the content into a Paper component, to separate the content from the background:

<img width="1727" alt="image" src="https://user-images.githubusercontent.com/1353142/174091938-ead309f1-104a-4c09-a44d-a10f9d249fa5.png">

The _Filters_ page, though, doesn't follow this and throws everything in the background instead:

<img width="1726" alt="image" src="https://user-images.githubusercontent.com/1353142/174092128-37e7a35c-94e3-48e6-93b5-65fcb4f68fba.png">

This small PR fixes the styling of the Filters page, putting all the content into a Paper component. Furthermore, it moves the add button to the `breadcrumbsControls` prop of Layout, which was designed for this purpose and adds a tooltip for it.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/1353142/174092711-fd56113e-aedb-42b5-acec-2eb7a8b7473b.png">

